### PR TITLE
chore: update package type to "module"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "mpc-framework",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mpc-framework",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "ee-typed": "^0.1.0",
-        "mpc-framework-common": "^0.1.0",
+        "ee-typed": "^0.1.1",
+        "mpc-framework-common": "^0.1.1",
         "msgpackr": "^1.11.0",
         "zod": "^3.23.8"
       },
@@ -20,7 +20,7 @@
         "chai": "^5.1.1",
         "emp-wasm-backend": "^0.1.0",
         "mocha": "^10.7.0",
-        "summon-ts": "^0.2.1",
+        "summon-ts": "^0.2.5",
         "tsx": "^4.16.5",
         "typescript": "^5.4.5"
       }
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/ee-typed": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ee-typed/-/ee-typed-0.1.0.tgz",
-      "integrity": "sha512-tLlZ5IrB0KGJYTtqawcyY5Bl7T3ssUyq1huccSrj1X8qlSdStu0D+ShzMZaZOQubxnPXFMhjcB2+RKJqeYu00Q==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ee-typed/-/ee-typed-0.1.1.tgz",
+      "integrity": "sha512-atfgRdyoqK/QOY7dqv4jwAi7th45DDX2zRjGgLR8zRgJy7QSLyoS6aI1jZbKf/VIrXy9YTpHFCr8Mzxj//a/KA==",
       "dependencies": {
         "@types/node": "^20.14.2",
         "typed-emitter": "^2.1.0"
@@ -831,9 +831,9 @@
       "dev": true
     },
     "node_modules/emp-wasm": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/emp-wasm/-/emp-wasm-0.1.3.tgz",
-      "integrity": "sha512-si/alEkEkX51ZwmGem6PScrTA8YOg82axjCEOGhqWg0K9XHuDmFy8hYOfFA7Y0pWbukN69oFKqx4PKKG7X0Rvw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/emp-wasm/-/emp-wasm-0.1.7.tgz",
+      "integrity": "sha512-GaivW3JA8Pxe1DxtD7ZSBhso93cqBFRIApppkkkM/qI55mueEYwXhE3hRn9I/yjmJkbnYYlto5plGJ8mEYHDRw==",
       "dev": true,
       "dependencies": {
         "ee-typed": "^0.1.0",
@@ -1266,14 +1266,9 @@
       }
     },
     "node_modules/mpc-framework-common": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/mpc-framework-common/-/mpc-framework-common-0.1.0.tgz",
-      "integrity": "sha512-JeE7gKoqAC/9ZlGclHs/DCACi7KHfJZRZoQWU1GnO7hzHjPakJgZTfZFYXuvmEprP3olvMas7AQp3uVuixsI8Q==",
-      "dependencies": {
-        "ee-typed": "^0.1.0",
-        "msgpackr": "^1.11.0",
-        "zod": "^3.23.8"
-      }
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/mpc-framework-common/-/mpc-framework-common-0.1.1.tgz",
+      "integrity": "sha512-D+o1vSdFPl9v55c0kgM2dGcUR0IZQn3teeQHA5pWiwjokbMt7uiNHHqQKyrzsY2Y4TfBbVKjnS9yjM6szIO5Ng=="
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1527,9 +1522,9 @@
       }
     },
     "node_modules/summon-ts": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/summon-ts/-/summon-ts-0.2.1.tgz",
-      "integrity": "sha512-Xc+584n4+sa1h1qO3FJP4YXvBukMmTAAm2z51ysXoVLdlseH7f2Ua02o15xSnw5bOTLV5dErbNOZUcExQOPMFQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/summon-ts/-/summon-ts-0.2.5.tgz",
+      "integrity": "sha512-VtsdFLyvctiYzgfXFH18UlD5u9Do8aNU0sBxiiDT0Tqdru1vAT+LfBwLSRfisry5avEUheYWMFL/5Hix3rIo5Q==",
       "dev": true
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "mpc-framework",
   "version": "0.1.2",
   "description": "MPC framework supporting a variety of circuit generators and backends",
+  "type": "module",
   "main": "dist/src/index.js",
   "scripts": {
     "build": "rm -rf dist && tsc",
@@ -27,13 +28,13 @@
     "chai": "^5.1.1",
     "emp-wasm-backend": "^0.1.0",
     "mocha": "^10.7.0",
-    "summon-ts": "^0.2.1",
+    "summon-ts": "^0.2.5",
     "tsx": "^4.16.5",
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "ee-typed": "^0.1.0",
-    "mpc-framework-common": "^0.1.0",
+    "ee-typed": "^0.1.1",
+    "mpc-framework-common": "^0.1.1",
     "msgpackr": "^1.11.0",
     "zod": "^3.23.8"
   }

--- a/src/PlaintextBackend/PlaintextBackend.ts
+++ b/src/PlaintextBackend/PlaintextBackend.ts
@@ -1,5 +1,5 @@
-import PlaintextBackendHostSession from "./PlaintextBackendHostSession";
-import PlaintextBackendClientSession from "./PlaintextBackendClientSession";
+import PlaintextBackendHostSession from "./PlaintextBackendHostSession.js";
+import PlaintextBackendClientSession from "./PlaintextBackendClientSession.js";
 import { Backend, BackendSession, Circuit, MpcSettings } from "mpc-framework-common";
 
 export default class PlaintextBackend implements Backend {

--- a/src/PlaintextBackend/PlaintextBackendClientSession.ts
+++ b/src/PlaintextBackend/PlaintextBackendClientSession.ts
@@ -1,5 +1,5 @@
 import { pack, unpack } from "msgpackr";
-import defer from "../helpers/defer";
+import defer from "../helpers/defer.js";
 import { z } from "zod";
 import { BackendSession, Circuit, MpcSettings } from "mpc-framework-common";
 

--- a/src/PlaintextBackend/PlaintextBackendHostSession.ts
+++ b/src/PlaintextBackend/PlaintextBackendHostSession.ts
@@ -1,10 +1,10 @@
 import { pack, unpack } from "msgpackr";
 import z from 'zod';
 
-import delay from "../helpers/delay";
-import defer from "../helpers/defer";
-import evaluate, { u32Arithmetic } from "../helpers/evaluate";
-import errorToString from "../helpers/errorToString";
+import delay from "../helpers/delay.js";
+import defer from "../helpers/defer.js";
+import evaluate, { u32Arithmetic } from "../helpers/evaluate.js";
+import errorToString from "../helpers/errorToString.js";
 import { BackendSession, Circuit, MpcSettings } from "mpc-framework-common";
 
 export default class PlaintextBackendHostSession implements BackendSession {

--- a/src/Protocol.ts
+++ b/src/Protocol.ts
@@ -1,5 +1,5 @@
 import { Backend, Circuit, MpcSettings } from "mpc-framework-common";
-import Session from "./Session";
+import Session from "./Session.js";
 
 export default class Protocol {
   constructor(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-export { default as Protocol } from './Protocol';
-export { default as Session } from './Session';
-export { default as PlaintextBackend } from './PlaintextBackend/PlaintextBackend';
+export { default as Protocol } from './Protocol.js';
+export { default as Session } from './Session.js';
+export { default as PlaintextBackend } from './PlaintextBackend/PlaintextBackend.js';
 export {
   type Circuit,
   type Backend,


### PR DESCRIPTION
## What is this PR doing?

This PR resolves compatibility issues with Node.js by setting the package type to module in package.json. This ensures the package works in both modern browsers and Node.js environments.

Related: https://github.com/voltrevo/summon-ts/pull/1

This PR depends on https://github.com/voltrevo/emp-wasm-backend/pull/3. Before merging, the `emp-wasm-backend` dependency needs to be updated.

## How can these changes be manually tested?

It can be tested locally by trying to use this package from NodeJS.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat
