### PR TITLE
Improves deno compatibility by avoiding msgpackr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mpc-framework",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mpc-framework",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "ee-typed": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpc-framework",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "MPC framework supporting a variety of circuit generators and backends",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 export { default as Protocol } from './Protocol.js';
 export { default as Session } from './Session.js';
-export { default as PlaintextBackend } from './PlaintextBackend/PlaintextBackend.js';
 export {
   type Circuit,
   type Backend,
@@ -8,3 +7,8 @@ export {
   type MpcParticipantSettings,
   type MpcSettings,
 } from 'mpc-framework-common';
+
+// This is NOT exported because it is almost never wanted and depends
+// unnecessarily on msgpackr. Importing msgpackr creates a lot of permissions
+// noise in Deno on startup.
+// export { default as PlaintextBackend } from './PlaintextBackend/PlaintextBackend.js';


### PR DESCRIPTION
## What is this PR doing?

See title and comment in index.ts.

## How can these changes be manually tested?

```sh
npm install
npm run build
npm pack
```

Then import the .tgz file into `emp-wasm-backend` (replacing the npm version) and run `npm test` in that project.

## Does this PR resolve or contribute to any issues?

Contributes to https://www.notion.so/pse-team/Support-Deno-15ed57e8dd7e801497b6ee1a7813df12?pvs=4

## Checklist

- [x] I have manually tested these changes
- [ ] Post a link to the PR in the group chat

## Guidelines

- If your PR is not ready, mark it as a draft
